### PR TITLE
[#65] fix(directory) - 폴더 디렉토리 구조 수정 및 버그 수정

### DIFF
--- a/frontend/components/Container/index.ts
+++ b/frontend/components/Container/index.ts
@@ -60,6 +60,11 @@ export class Container extends Component<RouterView> {
     router.on(ROUTER.CHANGE_DATE, ({ year, month }) => {
       // TODO: backend invociecs
       const mockData = month % 2 == 0 ? mockup : []
+      const invoices = mockData
+      invoices.forEach((invoice) => {
+        this.categoryModel.fillInvoice(invoice)
+        this.paymentModel.fillInvoice(invoice)
+      })
       this.invoiceModel.setInvoices(mockData)
     })
     router.on(

--- a/frontend/components/List/index.ts
+++ b/frontend/components/List/index.ts
@@ -34,17 +34,6 @@ export class List extends Component<ListView, Container> {
     this.invoiceModel.on(EVENT.SET_INVOICES, (invoices) => {
       this.view.clear()
       invoices.forEach((invoice: Invoice) => {
-        const category = this.categoryModel.findCategoryById(
-          invoice.category.id
-        )
-        invoice.category.type = category.type
-        invoice.category.title = category.title
-
-        const payment = this.paymentModel.findPaymentMethodsById(
-          invoice.paymentMethod.id
-        )
-        invoice.paymentMethod.title = payment.title
-
         this.view.addInvoice(invoice, false)
       })
     })

--- a/frontend/components/Login.ts
+++ b/frontend/components/Login.ts
@@ -1,4 +1,0 @@
-import { Component } from '.'
-import LoginView from './Login/view'
-
-export class Login extends Component<LoginView> {}

--- a/frontend/components/Login/index.ts
+++ b/frontend/components/Login/index.ts
@@ -1,0 +1,4 @@
+import { Component } from '..'
+import LoginView from './view'
+
+export class Login extends Component<LoginView> {}

--- a/frontend/components/Main/index.ts
+++ b/frontend/components/Main/index.ts
@@ -1,10 +1,10 @@
-import { Component } from '.'
-import router from '../router'
-import { ROUTER } from '../utils/constants'
-import { Login } from './Login'
-import LoginView from './Login/view'
-import MainView from './Main/view'
-import NavigationView from './Navigator/view'
+import { Component } from '..'
+import router from '../../router'
+import { ROUTER } from '../../utils/constants'
+import { Login } from '../Login'
+import LoginView from '../Login/view'
+import NavigationView from '../Navigator/view'
+import MainView from './view'
 export class Main extends Component<MainView> {
   navigationView: NavigationView
   loginView: LoginView
@@ -18,15 +18,14 @@ export class Main extends Component<MainView> {
       this.navigationView.setDate(year, month)
     })
     router.on(ROUTER.MUTATE_VIEW, ({ path, flag }) => {
-      if (path === 'login') {
-        if (flag) {
-          this.navigationView.remove()
-          this.loginView.appendToView(this.view)
-          return
-        }
-        this.loginView.remove()
-        this.navigationView.appendToView(this.view)
+      if (path !== 'login') return
+      if (flag) {
+        this.navigationView.remove()
+        this.loginView.appendToView(this.view)
+        return
       }
+      this.loginView.remove()
+      this.navigationView.appendToView(this.view)
     })
     this.navigationView = this.view.navigatorView
   }

--- a/frontend/model/CategoryModel.ts
+++ b/frontend/model/CategoryModel.ts
@@ -1,10 +1,15 @@
 import { Observable } from '.'
-import { Category } from '../../types'
+import { Category, Invoice } from '../../types'
 import { EVENT } from '../utils/constants'
 
 export class CategoryModel extends Observable {
   categories: Array<Category> = []
 
+  fillInvoice(invoice: Invoice) {
+    const category = this.findCategoryById(invoice.category.id)
+    invoice.category.type = category.type
+    invoice.category.title = category.title
+  }
   setCategories(categories: Array<Category>) {
     this.clear()
     this.categories = categories

--- a/frontend/model/PaymentModel.ts
+++ b/frontend/model/PaymentModel.ts
@@ -1,10 +1,14 @@
 import { Observable } from '.'
-import { PaymentMethod } from '../../types'
+import { Invoice, PaymentMethod } from '../../types'
 import { EVENT } from '../utils/constants'
 
 export class PaymentModel extends Observable {
   paymentMethods: Array<PaymentMethod> = []
 
+  fillInvoice(invoice: Invoice) {
+    const payment = this.findPaymentMethodsById(invoice.paymentMethod.id)
+    invoice.paymentMethod.title = payment.title
+  }
   addPaymentMethod(paymentMethod: PaymentMethod) {
     this.paymentMethods = [...this.paymentMethods, paymentMethod]
     this.emit(EVENT.ADD_PAYMENT, paymentMethod)


### PR DESCRIPTION
### 변경사항
- Main과 Login 컴포넌트가 Main, Login 폴더에 누락되어 있는 것을 추가
- `localhost:9000/chart` 에 바로 접근할 시 그래프의 내용이 비어있는 버그 수정

### 의논해야할 사항
- 위의 버그는 invoices에 Category 내용을 채워넣는 로직이 List 컴포넌트에 있었기 떄문에, 바로 URL로 /chart에 접근하면 리스트 컴포넌트를 거치지 않아서 발생하는 코드였습니다. 해당 로직을 CategoryModel과 PaymentModel의 fillInvoice(invoice)라는 함수로 분리시키고, Container 컴포넌트에서 `this.invoiceModel.setInvoices(invoices)` 하는 부분으로 옮겨서 해결하기는 했습니다.
- 근데 이렇게 되면 무조건 invoiceModel보다 CategoryModel, PaymentModel의 정보를 빨리 서버에서 불러와야되는데, 네트워크 통신이 비동기다 보니 예외 상황이 발생할 수도 있고, 코드 흐름을 제어하기도 힘들어질 것 같습니다.
- 이렇게 되면 invoice에 category를 채워넣는 코드를 서버에서 처리하는 것도 하나의 방법이 될 수도??

### Related Issues
resolve #65 