### PR TITLE
Feat/87 router

### DIFF
--- a/frontend/components/Container/index.ts
+++ b/frontend/components/Container/index.ts
@@ -4,7 +4,7 @@ import { CategoryModel } from '../../model/CategoryModel'
 import { InvoiceModel } from '../../model/InvoiceModel'
 import { PaymentModel } from '../../model/PaymentModel'
 import router from '../../router'
-import { ROUTER } from '../../utils/constants'
+import { ROUTE, ROUTER, ROUTES } from '../../utils/constants'
 import { App } from '../app'
 import { Calendar } from '../Calendar'
 import { Chart } from '../Chart'
@@ -12,23 +12,23 @@ import { Filter } from '../Filter'
 import { Form } from '../Form'
 import { List } from '../List'
 import { mockupCategory, mockupPayment } from '../mockup'
+import { View } from '../view'
 import ContainerView from './view'
 
 export class Container extends Component<ContainerView, App> {
-  invoiceModel: InvoiceModel
-  categoryModel: CategoryModel
+  invoiceModel: InvoiceModel = new InvoiceModel()
+  categoryModel: CategoryModel = new CategoryModel()
   paymentModel: PaymentModel
   list: List
   filter: Filter
   form: Form
   calendar: Calendar
   chart: Chart
+  routerMap: Map<string, Component<View>> = new Map<string, Component<View>>()
 
   constructor(parent, view: ContainerView) {
     super(parent, view)
 
-    this.invoiceModel = new InvoiceModel()
-    this.categoryModel = new CategoryModel()
     this.paymentModel = this.parent.paymentModel
 
     this.list = new List(this, this.view.listView)
@@ -40,11 +40,11 @@ export class Container extends Component<ContainerView, App> {
     this.categoryModel.setCategories(mockupCategory)
     this.paymentModel.setPaymentMethods(mockupPayment)
 
-    router.add('list', [this.form, this.filter, this.list])
-    router.add('calendar', [this.filter, this.calendar])
-    router.add('chart', [this.chart])
+    this.routerMap[ROUTE.LIST] = [this.form, this.filter, this.list]
+    this.routerMap[ROUTE.CALENDAR] = [this.filter, this.calendar]
+    this.routerMap[ROUTE.CHART] = [this.chart]
+
     router.on(ROUTER.CHANGE_DATE, async ({ year, month }) => {
-      // TODO: backend invociecs
       const { invoiceList } = await api.fetchInvoices(year, month)
       invoiceList.forEach((invoice) => {
         invoice.date = new Date(invoice.date)
@@ -55,16 +55,10 @@ export class Container extends Component<ContainerView, App> {
     })
     router.on(
       ROUTER.MUTATE_VIEW,
-      ({
-        path,
-        flag,
-        components,
-      }: {
-        path: string
-        flag: boolean
-        components: Component<any>[]
-      }) => {
-        if (path !== 'list' && path !== 'calendar' && path !== 'chart') return
+      ({ path, flag }: { path: string; flag: boolean }) => {
+        if (!ROUTES.CONTAINER.includes(path)) return
+        if (router.isInvalidPath(path)) return
+        const components = this.routerMap[path]
         if (flag) {
           components.forEach((component) => {
             const view = component.view

--- a/frontend/components/app.ts
+++ b/frontend/components/app.ts
@@ -15,28 +15,26 @@ import { View } from './view'
 const template: string = `<div id="app"></div>`
 
 export class AppView extends View {
-  modalView: ModalView
-  headerView: HeaderView
-  containerView: ContainerView
-  loginView: LoginView
+  modalView: ModalView = new ModalView()
+  headerView: HeaderView = new HeaderView()
+  containerView: ContainerView = new ContainerView()
+  loginView: LoginView = new LoginView()
 
   constructor() {
     super(template)
+    this.appendChildViews()
   }
-
-  mount(): void {
-    this.modalView = new ModalView()
-    this.headerView = new HeaderView()
-    this.containerView = new ContainerView()
-    this.loginView = new LoginView()
-
+  appendChildViews() {
     this.modalView.appendToView(this)
+    this.loginView.appendToView(this)
+    this.headerView.appendToView(this)
     this.containerView.appendToView(this)
   }
+  mount(): void {}
 }
 
 export class App extends Component<AppView> {
-  paymentModel: PaymentModel
+  paymentModel: PaymentModel = new PaymentModel()
   header: Header
   modal: Modal
   container: Container
@@ -45,8 +43,6 @@ export class App extends Component<AppView> {
   constructor(view: AppView) {
     super(null, view)
 
-    this.paymentModel = new PaymentModel()
-
     this.header = new Header(this, this.view.headerView)
     this.modal = new Modal(this, this.view.modalView)
     this.container = new Container(this, this.view.containerView)
@@ -54,16 +50,12 @@ export class App extends Component<AppView> {
 
     router.on(ROUTER.MUTATE_VIEW, ({ path, flag }) => {
       if (path === ROUTE.LOGIN && flag) {
-        this.header.view.remove()
-        this.login.view.appendToView(this.view)
+        this.header.view.hide()
+        this.login.view.show()
         return
       }
-      if (!this.header.view.isAttached()) {
-        this.login.view.remove()
-        this.header.view.prependToView(this.view)
-      }
+      this.login.view.hide()
+      this.header.view.show()
     })
-
-    // set child components
   }
 }

--- a/frontend/components/app.ts
+++ b/frontend/components/app.ts
@@ -1,7 +1,7 @@
 import { Component } from '.'
 import { PaymentModel } from '../model/PaymentModel'
 import router from '../router'
-import { ROUTER } from '../utils/constants'
+import { ROUTE, ROUTER } from '../utils/constants'
 import { Container } from './Container'
 import ContainerView from './Container/view'
 import { Header } from './Header'
@@ -52,9 +52,8 @@ export class App extends Component<AppView> {
     this.container = new Container(this, this.view.containerView)
     this.login = new Login(this, this.view.loginView)
 
-    router.add('login', [this.login])
     router.on(ROUTER.MUTATE_VIEW, ({ path, flag }) => {
-      if (path === 'login' && flag) {
+      if (path === ROUTE.LOGIN && flag) {
         this.header.view.remove()
         this.login.view.appendToView(this.view)
         return

--- a/frontend/router.ts
+++ b/frontend/router.ts
@@ -67,7 +67,8 @@ class Router extends Observable {
       return
     }
     if (path === '') this.go(ROUTE.LIST)
-    if (!this.isInvalidPath(path)) this.go(path)
+if (this.isInvalidPath(path)) return
+ this.go(path)
   }
   commitDateChange() {
     this.emit(ROUTER.CHANGE_DATE, { year: this.year, month: this.month })

--- a/frontend/utils/constants.ts
+++ b/frontend/utils/constants.ts
@@ -36,6 +36,20 @@ export const ROUTER = {
   CHANGE_DATE: 'CHANGE_DATE',
 }
 
+export const ROUTE = {
+  LOGIN: 'login',
+  LIST: 'list',
+  CALENDAR: 'calendar',
+  CHART: 'chart',
+  PREVIOUS_MONTH: 'previous-month',
+  NEXT_MONTH: 'next-month',
+}
+export const ROUTES = {
+  CONTAINER: [ROUTE.LIST, ROUTE.CALENDAR, ROUTE.CHART],
+  LOGIN: [ROUTE.LOGIN],
+  ALL: [ROUTE.LIST, ROUTE.CALENDAR, ROUTE.CHART, ROUTE.LOGIN],
+}
+
 export const FORM_CLASS = {
   INPUT_AMOUNT: 'input-amount',
   INPUT_DATE: 'input-date',


### PR DESCRIPTION
### Refactoring
- router.add() 삭제 - 라우터에서 어차피 모델에는 접근 못하기 때문에 굳이 모든 컴포넌트의 정보를 저장할 필요는 없는 것 같다.. 라우터 분기는 컴포넌트에서 하는 걸로..
- 매직 넘버 constants로 이동
- 이벤트 핸들러 코드 메소드로 분리
- 달력 네비게이션은 this.go가 아니라 click에서 처리하기 (go함수의 크기가 너무커서 책임 분담)
- 저번 풀 리퀘스트 피드백 반영 -> 로그인 라우팅 시 뷰 숨김/보여짐으로 변경

### Related Issues
- resolve #87 