### PR TITLE
Feat/78 chart

### DIFF
--- a/frontend/components/Chart/BarChartView.ts
+++ b/frontend/components/Chart/BarChartView.ts
@@ -1,7 +1,86 @@
 import router from '../../router'
+import { formatAmount } from '../../utils'
 import { createSVGCircle, createSVGLine, createSVGText, View } from '../view'
 import config from './config'
 import { barChartTemplate } from './template'
+
+function range(idx) {
+  return Array.from({ length: idx }, (_, i) => i)
+}
+
+function getOffsetX(dayN) {
+  const { width, padding } = config
+  return (width - padding * 2) / dayN
+}
+
+function createConnectionLines(dayN) {
+  const { height, padding, paddingY } = config
+  const y = height - paddingY
+  const offsetX = getOffsetX(dayN)
+  return range(dayN - 1).map((i) =>
+    createSVGLine({
+      className: 'connection-line',
+      id: `l${i + 1}`,
+      x1: padding + offsetX * (i + 2) - offsetX,
+      x2: padding + offsetX * (i + 2),
+      y1: y,
+      y2: y,
+    })
+  )
+}
+function createDateCircles(dayN) {
+  const { height, paddingY, padding } = config
+  const y = height - paddingY
+  const offsetX = getOffsetX(dayN)
+  return range(dayN - 1).map((i) =>
+    createSVGCircle({
+      id: `c${i + 1}`,
+      className: 'date-circle',
+      cx: padding + offsetX * (i + 1),
+      cy: y,
+    })
+  )
+}
+function createDateNumbers(dayN) {
+  const { height, paddingY, padding, paddingX2 } = config
+  const y = height - paddingY + paddingX2
+  const offsetX = getOffsetX(dayN)
+  return range(dayN - 1).map((i) =>
+    createSVGText({
+      className: 'date-number',
+      id: `d${i + 1}`,
+      x: padding + offsetX * (i + 1),
+      y,
+      text: i + 1,
+    })
+  )
+}
+function createGridLines(lines) {
+  const { width, paddingX, paddingY, lineHeight } = config
+  return range(lines)
+    .map((i) => paddingY + lineHeight * (i + 1))
+    .map((y) =>
+      createSVGLine({
+        className: 'grid-line',
+        x1: paddingX,
+        x2: width - paddingX,
+        y1: y,
+        y2: y,
+      })
+    )
+}
+function createGridNumbers(lines) {
+  const { paddingX, paddingX2, paddingY, lineHeight } = config
+  return range(lines).map((i) =>
+    createSVGText({
+      className: 'grid-number',
+      id: `h${lines - i - 1}`,
+      x: paddingX - paddingX2,
+      y: paddingY + lineHeight * (i + 1) + 6,
+    })
+  )
+}
+
 export class BarChartView extends View {
   $barChart: SVGElement
 
@@ -21,7 +100,7 @@ export class BarChartView extends View {
     for (let i = 0; i < lines; i++) {
       const text = <SVGTextElement>this.$barChart.querySelector(`text#h${i}`)
       text.textContent =
-        height == 0 ? '' : String(Math.floor((height / (lines - 1)) * i))
+        height == 0 ? '' : formatAmount(Math.floor((height / (lines - 1)) * i))
     }
   }
   setBarHeight(date, ratio) {
@@ -51,64 +130,15 @@ export class BarChartView extends View {
   }
   initBarChart() {
     this.$barChart.innerHTML = ''
-    const {
-      height,
-      width,
-      paddingX,
-      paddingX2,
-      paddingY,
-      lines,
-      lineHeight,
-    } = config
+    const { lines } = config
     const dayN = new Date(router.year, router.month, 0).getDate()
-    for (let i = 1; i <= lines; i++) {
-      const y = paddingY + lineHeight * i
-      this.insertBarChartTemplate(
-        createSVGLine({
-          className: 'grid-line',
-          x1: paddingX,
-          x2: width - paddingX,
-          y1: y,
-          y2: y,
-        }),
-        createSVGText({
-          className: 'grid-number',
-          id: `h${lines - i}`,
-          x: paddingX - paddingX2,
-          y: y + 6,
-        })
-      )
-    }
-    const padding = paddingX + paddingX2
-    const offsetX = (width - padding * 2) / dayN
-    for (let i = 1; i <= dayN; i++) {
-      const x = padding + offsetX * i
-      const y = height - paddingY
-      this.insertBarChartTemplate(
-        i !== 1
-          ? createSVGLine({
-              className: 'connection-line',
-              id: `l${i - 1}`,
-              x1: x - offsetX,
-              x2: x,
-              y1: y,
-              y2: y,
-            })
-          : '',
-        createSVGCircle({
-          id: `c${i}`,
-          className: 'date-circle',
-          cx: x,
-          cy: y,
-        }),
-        createSVGText({
-          className: 'date-number',
-          id: `d${i}`,
-          x,
-          y: height - paddingY + paddingX2,
-          text: i,
-        })
-      )
-    }
+
+    this.insertBarChartTemplate(
+      ...createGridLines(lines),
+      ...createGridNumbers(lines),
+      ...createConnectionLines(dayN),
+      ...createDateCircles(dayN),
+      ...createDateNumbers(dayN)
+    )
   }
 }

--- a/frontend/components/Chart/PiChartView.ts
+++ b/frontend/components/Chart/PiChartView.ts
@@ -1,3 +1,4 @@
+import { formatAmount } from '../../utils'
 import { templateToElement } from '../../utils/ElementGenerator'
 import { setText, View } from '../view'
 import config from './config'
@@ -15,9 +16,9 @@ function createPiTableItemElement({ title, ratio, amount, idx }) {
   const $itemColorBar = $piTableItem.querySelector('.item-color-bar')
   $itemColorBar.setAttribute(
     'style',
-    `width: ${ratio * width}px; background-color: ${circleColors[idx]}`
+    `width: ${ratio * width * 0.8}px; background-color: ${circleColors[idx]}`
   )
-  setText($piTableItem, '.item-amount', amount)
+  setText($piTableItem, '.item-amount', `${formatAmount(amount)}원`)
   return $piTableItem
 }
 

--- a/frontend/components/Chart/PiChartView.ts
+++ b/frontend/components/Chart/PiChartView.ts
@@ -2,7 +2,11 @@ import { formatAmount } from '../../utils'
 import { templateToElement } from '../../utils/ElementGenerator'
 import { setText, View } from '../view'
 import config from './config'
-import { piChartTemplate, piItemTemplate } from './template'
+import {
+  noDataAlertTemplate,
+  piChartTemplate,
+  piItemTemplate,
+} from './template'
 function dx(r, ang) {
   return r * Math.cos(((ang - 90) / 180) * Math.PI)
 }
@@ -64,22 +68,19 @@ export class PiChartView extends View {
 
   renderPiChart(arr) {
     this.$piChart.innerHTML = ''
+    this.$piTable.innerHTML = ''
+    const totalAmount = arr.reduce((a, b) => a + b.amount, 0)
     const { circles } = config
     let ang = 0
-    arr.slice(0, circles).forEach(({ title, ang: theta }, idx) => {
+    if (arr.length === 0) {
+      this.insertPiChartTemplate(noDataAlertTemplate)
+    }
+    arr.slice(0, circles).forEach(({ title, ang: theta, amount }, idx) => {
       this.insertPiChartTemplate(
         createPiIndicatorLine({ ang: ang + theta / 2, title }),
         createPiArc({ ang, theta, idx })
       )
       ang += theta
-    })
-    this.renderPiTable(arr)
-  }
-  renderPiTable(arr) {
-    const { circles } = config
-    this.$piTable.innerHTML = ''
-    const totalAmount = arr.reduce((a, b) => a + b.amount, 0)
-    arr.slice(0, circles).forEach(({ title, amount }, idx) => {
       this.$piTable.appendChild(
         createPiTableItemElement({
           title,

--- a/frontend/components/Chart/config.ts
+++ b/frontend/components/Chart/config.ts
@@ -16,4 +16,5 @@ export default {
   radius: config.height / 3,
   cx: config.width / 2,
   cy: config.height / 2,
+  padding: config.paddingX + config.paddingX2,
 }

--- a/frontend/components/Chart/style.scss
+++ b/frontend/components/Chart/style.scss
@@ -1,6 +1,16 @@
 @use '@/static/styles/package' as *;
 #invoice-chart {
   height: auto;
+  #chart-selector {
+    margin: 0 auto;
+    width: 30%;
+  }
+  #bar-chart {
+    position: relative;
+  }
+  #bar-display {
+    position: absolute;
+  }
 }
 
 svg {
@@ -25,11 +35,16 @@ svg {
   stroke: black;
   r: 3;
 }
+.header-3 {
+  font-size: 18px;
+  margin: 15px 0px;
+}
 .date-number {
   font-size: 0.8rem;
 }
 h3 {
   font-size: 1.2rem;
+  margin: 10px;
 }
 .item-bar {
   margin: 5px;

--- a/frontend/components/Chart/style.scss
+++ b/frontend/components/Chart/style.scss
@@ -10,8 +10,8 @@
   }
   #bar-display {
     position: absolute;
-    background-color: black;
-    color: white;
+    background-color: $color-black;
+    color: $color-white;
     border-radius: 4px;
     opacity: 0;
     font-size: 14px;

--- a/frontend/components/Chart/style.scss
+++ b/frontend/components/Chart/style.scss
@@ -10,6 +10,17 @@
   }
   #bar-display {
     position: absolute;
+    background-color: black;
+    color: white;
+    border-radius: 4px;
+    opacity: 0;
+    font-size: 14px;
+    padding: 4px;
+
+    &:not(.hidden2) {
+      opacity: 0.65;
+      transition-duration: 0.25s;
+    }
   }
 }
 
@@ -33,7 +44,12 @@ svg {
 }
 .date-circle {
   stroke: black;
+  stroke-width: 2;
+  fill: white;
   r: 3;
+  &:hover {
+    r: 4;
+  }
 }
 .header-3 {
   font-size: 18px;
@@ -41,6 +57,14 @@ svg {
 }
 .date-number {
   font-size: 0.8rem;
+  text-anchor: middle;
+  &.selected {
+    opacity: 1;
+  }
+  &:not(.selected) {
+    opacity: 0.5;
+    transition-duration: 0.2s;
+  }
 }
 h3 {
   font-size: 1.2rem;

--- a/frontend/components/Chart/template.ts
+++ b/frontend/components/Chart/template.ts
@@ -20,7 +20,8 @@ export const barChartTemplate = /*html*/ `
 `
 export const piChartTemplate = /*html*/ `
   <div id="pi-chart">
-    <svg viewBox="0 0 800 400"></svg>
+    <svg viewBox="0 0 800 400">
+    </svg>
     <div class="header-3">
       항목별 합계
     </div>
@@ -28,7 +29,11 @@ export const piChartTemplate = /*html*/ `
     </div>
   </div>
 `
+export const noDataAlertTemplate = `
+  <circle cx="400" cy="200" r="132" fill="lightgrey"></circle>
+  <text id="no-data-alert" x="400" y="200" text-anchor="middle">표시할 정보가 없습니다.</text>
 
+`
 export const piItemTemplate = /*html*/ `
   <div class="row">
     <div class="item left item-title">

--- a/frontend/components/Chart/template.ts
+++ b/frontend/components/Chart/template.ts
@@ -15,15 +15,15 @@ export const template: string = /*html*/ `
 
 export const barChartTemplate = /*html*/ `
   <div id="bar-chart">
-    <small>bar-chart</small>
     <svg viewBox="0 0 800 400"></svg>
   </div>
 `
 export const piChartTemplate = /*html*/ `
   <div id="pi-chart">
-    <small>pi-chart</small>
     <svg viewBox="0 0 800 400"></svg>
-    <h3>항목별 합계</h3>
+    <div class="header-3">
+      항목별 합계
+    </div>
     <div id="pi-table" class="rows">
     </div>
   </div>
@@ -41,5 +41,10 @@ export const piItemTemplate = /*html*/ `
         </div>
       </div>
     </div>
+  </div>
+`
+
+export const barDisplayTemplate = `
+  <div id="bar-display">
   </div>
 `

--- a/frontend/components/List/style.scss
+++ b/frontend/components/List/style.scss
@@ -7,8 +7,11 @@
     .date-row {
       border-top: 1px solid $color-gray-600;
       padding: 11px 0;
+      align-items: center;
 
       .item {
+        justify-content: flex-end;
+
         .date {
           font-size: 16px;
           font-weight: 600;
@@ -16,28 +19,23 @@
         }
 
         .day {
-          font-size: 16px;
+          font-size: 16;
           color: $color-gray-800;
         }
+      }
+      .sum-box {
+        font-size: 14px;
+        font-weight: 200;
+        display: flex;
 
-        .earning-sum,
-        .spending-sum {
-          font-size: 16px;
-          font-weight: 600;
+        .earning-sum-box {
+          margin-right: 5px;
+          * {
+            color: $color-main;
+          }
         }
 
-        .earning-sum,
-        .earning-sum-pre,
-        .earning-sum-post {
-          color: $color-main;
-        }
-        .earning-sum-post {
-          margin-right: 8px;
-        }
-
-        .spending-sum,
-        .spending-sum-pre,
-        .spending-sum-post {
+        .spending-sum-box * {
           color: $color-complementary;
         }
       }

--- a/frontend/components/List/style.scss
+++ b/frontend/components/List/style.scss
@@ -19,7 +19,7 @@
         }
 
         .day {
-          font-size: 16;
+          font-size: 16px;
           color: $color-gray-800;
         }
       }

--- a/frontend/components/List/template.ts
+++ b/frontend/components/List/template.ts
@@ -9,13 +9,17 @@ export const wrapperRowTemplate: string = /*html*/ `
       <div class="item left">
         <span class="date"></span><span class="day"></span><span class="hidden-date hidden"></span>
       </div>
-      <div class="item right">
-        <div class="earning-sum-pre">+</div>
-        <div class="earning-sum">0</div>
-        <div class="earning-sum-post">원</div>
-        <div class="spending-sum-pre">–</div>
-        <div class="spending-sum">0</div>
-        <div class="spending-sum-post">원</div>
+      <div class="item right sum-box row">
+        <span class="item left earning-sum-box">
+          <span>+</span>
+          <span class="earning-sum">0</span>
+          <span>원</span>
+        </span>
+        <span class="item right spending-sum-box">
+          <span>–</span>
+          <span class="spending-sum">0</span>
+          <span>원</span>
+        </span>
       </div>
     </div>
     <div class="rows">

--- a/frontend/components/List/view.ts
+++ b/frontend/components/List/view.ts
@@ -17,7 +17,6 @@ function getPrettyDay(date: Date) {
 function removeComma(str: string) {
   return str.replace(/,/g, '')
 }
-
 function addAmountInWrapperRowSum(
   invoice: Invoice,
   $wrapperRow: HTMLDivElement
@@ -127,6 +126,9 @@ export default class ListView extends View {
       $row.classList.add('hidden')
     }
   }
+  getWrapperRows() {
+    return Array.from(this.queryAll('.invoice-wrapper'))
+  }
   getInvoiceRows() {
     return Array.from(this.queryAll('.invoice'))
   }
@@ -168,17 +170,39 @@ export default class ListView extends View {
     if (flag) $invoiceRow.classList.add('highlight')
     else $invoiceRow.classList.remove('highlight')
   }
-  setEarningVisible(flag: boolean) {
-    this.getInvoiceRowsByType(CONSTANT.EARNING).forEach(($row) => {
-      if (flag) $row.classList.remove('hidden')
-      else $row.classList.add('hidden')
+  setVisibilityCheck() {
+    this.getWrapperRows().forEach(($wrapperRow) => {
+      console.log('wrapperRow', $wrapperRow)
+      const isVisible = Array.from(
+        $wrapperRow.querySelector('.rows').children
+      ).some(($row) => !$row.classList.contains('hidden'))
+      if (isVisible) {
+        $wrapperRow.classList.remove('hidden')
+        return
+      }
+      $wrapperRow.classList.add('hidden')
     })
   }
-  setSpendingVisible(flag: boolean) {
-    this.getInvoiceRowsByType(CONSTANT.SPENDING).forEach(($row) => {
+  setVisibleByType(type, className, flag) {
+    this.getInvoiceRowsByType(type).forEach(($row) => {
       if (flag) $row.classList.remove('hidden')
       else $row.classList.add('hidden')
     })
+    this.getWrapperRows().forEach(($wrapperRow) => {
+      const $earningSumBox = $wrapperRow.querySelector(className)
+      if (flag) {
+        $earningSumBox.classList.remove('hidden')
+        return
+      }
+      $earningSumBox.classList.add('hidden')
+    })
+    this.setVisibilityCheck()
+  }
+  setEarningVisible(flag: boolean) {
+    this.setVisibleByType(CONSTANT.EARNING, '.earning-sum-box', flag)
+  }
+  setSpendingVisible(flag: boolean) {
+    this.setVisibleByType(CONSTANT.SPENDING, '.spending-sum-box', flag)
   }
   mount(): void {}
 }


### PR DESCRIPTION
### Refactoring 
- BarChart 코드 반복문으로 분리 (원이 무조건 선보다 빨리 앞으로 두기 위해)
### Feature
- 바 그래프에 콤마 찍기
- ListView에서 숨김 토글이 완벽하게 작동하도록 수정 (wrapperRow와 숫자도 숨긴다)
![image](https://user-images.githubusercontent.com/16265376/89558985-f6a13f00-d84f-11ea-9142-5101f86839a6.png)
![image](https://user-images.githubusercontent.com/16265376/89559018-01f46a80-d850-11ea-88c7-b9844c46de84.png)

### Style
- BarChart에 간단한 스타일, UX 적용
- PiChart에 데이터가 없을 경우 안내글 표시
- wrapperRow의 우측 폰트를 조금 줄임 (루카스에도 그렇게 나와있고 그게 더 보기 편한거 같아서..)
### Related Issues
- resolves #78
- #94

